### PR TITLE
Use mdbook in Zeit Now config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-yum install -y wget glibc
+yum install -y wget glibc-common
 
 wget https://github.com/rust-lang/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-yum install -y wget glib*
+yum install -y wget glibc*
 
 wget https://github.com/rust-lang/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-yum install -y wget glibc*
+yum install -y wget glibc
 
 wget https://github.com/rust-lang/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-yum install -y wget
+yum install -y wget glib*
 
 wget https://github.com/rust-lang/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,2 +1,7 @@
-mdbook build spec
-now spec/book --prod --name kdf
+yum install -y wget
+
+wget https://github.com/rust-lang/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz
+
+tar -xzf mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz
+
+./mdbook build spec

--- a/now.json
+++ b/now.json
@@ -1,0 +1,11 @@
+{
+  "name": "kdf",
+  "version": 2,
+  "builds": [
+    {
+      "src": "deploy.sh",
+      "use": "@now/static-build",
+      "config": { "distDir": "spec/book" }
+    }
+  ]
+}


### PR DESCRIPTION
This PR configures Zeit Now to download a mdbook binary, build the book, and then use this as the basis of the deployment.